### PR TITLE
Add Claude Code CLI configuration

### DIFF
--- a/.claude/commands/build-debug.md
+++ b/.claude/commands/build-debug.md
@@ -1,0 +1,11 @@
+Baue eine Debug-APK für das Android-Projekt:
+
+1. Führe `./gradlew clean` aus
+2. Führe `./gradlew assembleDebug` aus
+3. Überprüfe ob der Build erfolgreich war
+4. Zeige mir:
+   - Den Pfad zur generierten APK
+   - Die Dateigröße der APK
+   - Ob es Build-Warnungen gab
+
+Falls der Build fehlschlägt, analysiere die Fehler und schlage Lösungen vor.

--- a/.claude/commands/build-release.md
+++ b/.claude/commands/build-release.md
@@ -1,0 +1,16 @@
+Baue eine Release-APK für das Android-Projekt:
+
+WICHTIG: Dieser Build erfordert eine korrekt konfigurierte `keystore.properties` Datei.
+
+1. Überprüfe ob `keystore.properties` existiert (ohne den Inhalt zu lesen)
+2. Falls nicht vorhanden, warne den Benutzer und stoppe
+3. Falls vorhanden:
+   - Führe `./gradlew clean` aus
+   - Führe `./gradlew assembleRelease` aus
+4. Überprüfe ob der Build erfolgreich war
+5. Zeige mir:
+   - Den Pfad zur generierten Release-APK
+   - Die Dateigröße der APK
+   - Ob die APK signiert wurde
+
+Falls der Build fehlschlägt, analysiere die Fehler und schlage Lösungen vor (ohne sensible Keystore-Informationen zu zeigen).

--- a/.claude/commands/check-permissions.md
+++ b/.claude/commands/check-permissions.md
@@ -1,0 +1,22 @@
+Überprüfe die Android-Permissions im Projekt:
+
+1. Lese die `app/src/main/AndroidManifest.xml` Datei
+2. Analysiere alle `<uses-permission>` Einträge
+3. Erstelle einen Bericht mit:
+   - Liste aller Permissions
+   - Kategorisierung in: Normal, Dangerous, Signature
+   - Prüfe ob alle Dangerous Permissions im Code auch zur Laufzeit abgefragt werden
+   - Identifiziere unnötige oder veraltete Permissions
+
+4. Vergleiche mit den in CLAUDE.md dokumentierten Permissions:
+   - READ_CALENDAR, WRITE_CALENDAR
+   - READ_CONTACTS
+   - SEND_SMS
+   - POST_NOTIFICATIONS (API 33+)
+   - SCHEDULE_EXACT_ALARM
+   - RECEIVE_BOOT_COMPLETED
+
+5. Gib Empfehlungen für:
+   - Fehlende Permissions die noch benötigt werden
+   - Überflüssige Permissions die entfernt werden können
+   - Permissions die noch eine Runtime-Abfrage brauchen

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,11 @@
+Führe die Unit-Tests für das Android-Projekt aus:
+
+1. Führe `./gradlew clean` aus
+2. Führe `./gradlew test` aus
+3. Analysiere die Test-Ergebnisse und zeige mir:
+   - Anzahl der erfolgreichen Tests
+   - Anzahl der fehlgeschlagenen Tests
+   - Details zu allen Fehlern (falls vorhanden)
+4. Wenn Tests fehlschlagen, zeige mir die relevanten Log-Ausgaben
+
+Falls es Fehler gibt, schlage konkrete Lösungen vor.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "permissions": {
+    "deny": [
+      "**/build/**",
+      "**/.gradle/**",
+      "**/keystore.properties",
+      "**/*.jks",
+      "**/*.keystore",
+      "**/.idea/**",
+      "**/local.properties",
+      "**/.git/**"
+    ]
+  },
+  "context": {
+    "alwaysInclude": [
+      "CLAUDE.md",
+      "app/build.gradle.kts",
+      "gradle.properties"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ google-services.json
 
 # Android Profiling
 *.hprof
+
+# Claude Code local settings (keep personal settings out of version control)
+.claude/settings.local.json


### PR DESCRIPTION
Fügt Claude Code Konfiguration und Commands hinzu:

- .claude/settings.json: Berechtigungen für sensible Dateien (Keystore, Build-Ordner)
- .claude/commands/test.md: Unit-Tests ausführen
- .claude/commands/build-debug.md: Debug-APK bauen
- .claude/commands/build-release.md: Release-APK bauen
- .claude/commands/check-permissions.md: AndroidManifest Permissions analysieren
- .gitignore: Ignoriere .claude/settings.local.json

Diese Konfiguration ermöglicht effizientere Zusammenarbeit mit Claude Code durch wiederverwendbare Commands und sichere Berechtigungen.